### PR TITLE
Unit-categories

### DIFF
--- a/DCS-Quoll/Scripts/DCS-QuollGameGUI.lua
+++ b/DCS-Quoll/Scripts/DCS-QuollGameGUI.lua
@@ -146,10 +146,10 @@ Quoll.onChangeSlot = function(time, playerID, slotID, prevSide)
 end
 
 Quoll.getUnitTypeCategory = function(unitType)
-    local category = DCS.getUnitTypeAttribute(victimUnitType, "category")
+    local category = DCS.getUnitTypeAttribute(unitType, "category")
     if category == nil then
-        local deckLevel = DCS.getUnitTypeAttribute(victimUnitType, "DeckLevel")
-        local wingSpan = DCS.getUnitTypeAttribute(victimUnitType, "WingSpan")
+        local deckLevel = DCS.getUnitTypeAttribute(unitType, "DeckLevel")
+        local wingSpan = DCS.getUnitTypeAttribute(unitType, "WingSpan")
         if deckLevel ~= nil and wingSpan == nil then
             category = "Ships"
         elseif deckLevel == nil and wingSpan ~= nil then
@@ -187,11 +187,11 @@ Quoll.onKill = function(time, killerPlayerID, killerUnitType, killerSide, victim
         victim.ucid = ""
     end
 
-    local killerCategory = Quoll.getUnitTypeCategory(killerUnitType)
-    local victimCategory = Quoll.getUnitTypeCategory(victimUnitType)
+    local killerUnitCategory = Quoll.getUnitTypeCategory(killerUnitType)
+    local victimUnitCategory = Quoll.getUnitTypeCategory(victimUnitType)
 
-    Quoll.log("Killer Unit Category = "..killerCategory)
-    Quoll.log("Victim Unit Category = "..victimCategory)
+    Quoll.log("Killer Unit Category = "..killerUnitCategory)
+    Quoll.log("Victim Unit Category = "..victimUnitCategory)
 
     Quoll.log(killer.name.."("..killerUnitType..") destroyed "..victim.name.." ("..victimUnitType..") with "..weaponName)
 
@@ -201,12 +201,12 @@ Quoll.onKill = function(time, killerPlayerID, killerUnitType, killerSide, victim
     event.killerUcid = killer.ucid
     event.killerName = killer.name
     event.killerUnitType = killerUnitType
-    event.killerCategory = killerCategory
+    event.killerUnitCategory = killerUnitCategory
     event.killerSide = killerSide
     event.victimName = victim.name
     event.victimUcid = victim.ucid
     event.victimUnitType = victimUnitType
-    event.victimCategory = victimCategory
+    event.victimUnitCategory = victimUnitCategory
     event.victimSide = victimSide
     event.weaponName = weaponName
     Quoll.sendEvent(event)

--- a/app/socket.js
+++ b/app/socket.js
@@ -290,9 +290,11 @@ server.on('message', (msg, rinfo) => {
           killer_ucid: event.killerUcid,
           killer_name: event.killerName,
           killer_unit_name: event.killerUnitType,
+          killer_unit_category: event.killerUnitCategory,
           victim_ucid: event.victimUcid,
           victim_name: event.victimName,
           victim_unit_name: event.victimUnitType,
+          victim_unit_category: event.victimUnitCategory,
           weapon_name: event.weaponName
         }
       }
@@ -306,6 +308,7 @@ server.on('message', (msg, rinfo) => {
           player_ucid: event.playerUcid,
           player_name: event.playerName,
           unit_type: event.unitType,
+          unit_category: event.unitCategory,
           airdrome_name: event.airdromeName
         }
       }
@@ -320,6 +323,7 @@ server.on('message', (msg, rinfo) => {
           player_ucid: event.playerUcid,
           player_name: event.playerName,
           unit_type: event.unitType,
+          unit_category: event.unitCategory
         }
       }
       break;


### PR DESCRIPTION
Infers unit categories based off certain attributes. Sends with events where unit type is sent. Allows for badges based on categories.

Deploy:
- copy script to `Saved Games\DCS.openbeta_server\Mods\Services\DCS-Quoll\Scripts`
- build and package app 