### PR TITLE
Send welcome message to pilot on connect

### DIFF
--- a/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
+++ b/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
@@ -82,6 +82,26 @@ function Checkride.sendChatToAll(message)
     Checkride.log("Chat send API not available")
 end
 
+function Checkride.sendChatToUcid(message, ucid)
+    if not message or message == "" or not ucid or ucid == "" then
+        return
+    end
+
+    for id, player in pairs(Checkride.clients) do
+        if player.ucid == ucid then
+            if net and net.send_chat_to then
+                net.send_chat_to(message, id)
+            else
+                Checkride.log("send_chat_to API not available, falling back to broadcast")
+                Checkride.sendChatToAll(message)
+            end
+            return
+        end
+    end
+
+    Checkride.log("sendChatToUcid: no connected player found for ucid " .. ucid)
+end
+
 function Checkride.pollChatSocket()
     if not Checkride.UDPReceiveSocket then
         return
@@ -111,7 +131,11 @@ function Checkride.pollChatSocket()
 
                 if message and message ~= "" then
                     Checkride.log("Received chat message: " .. message)
-                    Checkride.sendChatToAll(message)
+                    if decoded.playerUcid and decoded.playerUcid ~= "" then
+                        Checkride.sendChatToUcid(message, decoded.playerUcid)
+                    else
+                        Checkride.sendChatToAll(message)
+                    end
                 end
             end
         elseif message and message ~= "" then

--- a/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
+++ b/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
@@ -213,6 +213,11 @@ local function getPlayerOrAI(playerID)
     return Checkride.clients[playerID] or { name = "AI", ucid = "" }
 end
 
+local function getConnectedPlayerCount()
+    local players = net.get_player_list()
+    return players and #players or 0
+end
+
 local function isBlank(value)
     return value == nil or tostring(value) == ""
 end
@@ -285,6 +290,7 @@ function Checkride.onConnect(time, playerID, name)
     local event = buildEvent("connect", time)
     event.playerUcid = player.ucid
     event.playerName = player.name
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 end
 
@@ -299,6 +305,7 @@ function Checkride.onDisconnect(time, playerID, name, playerSide, reason_code)
     event.playerName = player.name
     event.playerSide = playerSide
     event.reasonCode = reason_code
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 
     Checkride.removePlayer(playerID)
@@ -354,6 +361,7 @@ function Checkride.onChangeSlot(time, playerID, slotID, prevSide)
     event.slotId = slotID
     event.prevSide = prevSide
     event.flyable = isFlyableSlot(side, slotID)
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 end
 
@@ -535,4 +543,5 @@ Checkride.log("Checkride loaded v" .. Checkride.version)
 Checkride.sendEvent({
     type = "ready",
     luaClientVersion = Checkride.clientVersion,
+    playerCount = getConnectedPlayerCount(),
 })

--- a/app/appInit.js
+++ b/app/appInit.js
@@ -209,6 +209,14 @@ function attachEventPipeline({ udpServer, apiClient, discordClient, dcsChatClien
       engine.resetPilot(event.playerUcid);
       engine.loadAchievementsFromApi(event.playerUcid, apiClient)
         .catch((error) => log.error(`Failed to load achievements for pilot ${event.playerUcid}:`, error))
+
+      if (event.type === 'connect' && dcsChatClient?.send) {
+        dcsChatClient.send(
+          'You can view your pilot progression any time at https://www.checkride.oversweep.com',
+          true,
+          { kind: 'info', playerUcid: event.playerUcid }
+        ).catch((error) => log.error(`Failed to send welcome message to ${event.playerUcid}:`, error));
+      }
     }
 
     // Events with persist: false update pilot state and fire achievements but are never saved to the API.

--- a/app/appInit.js
+++ b/app/appInit.js
@@ -399,8 +399,7 @@ async function initApp({ onLuaVersionMismatch } = {}) {
   let connectedPlayerCount = 0;
   const originalOnEvent = udpServer.onEvent;
   udpServer.onEvent = (event) => {
-    if (event.type === 'connect') connectedPlayerCount++;
-    if (event.type === 'disconnect') connectedPlayerCount = Math.max(0, connectedPlayerCount - 1);
+    if (event.playerCount != null) connectedPlayerCount = event.playerCount;
     return originalOnEvent(event);
   };
 

--- a/app/build/lua-versioned/Mods/Services/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
+++ b/app/build/lua-versioned/Mods/Services/DCS-Checkride/Scripts/DCS-CheckrideGameGUI.lua
@@ -2,7 +2,7 @@
 -- DCS-Checkride Game Event Tracker
 -- ============================================================================
 Checkride = {}
-Checkride.clientVersion = "1.1.6"
+Checkride.clientVersion = "1.3.2-beta3"
 Checkride.version = Checkride.clientVersion
 Checkride.clients = {}
 
@@ -82,6 +82,26 @@ function Checkride.sendChatToAll(message)
     Checkride.log("Chat send API not available")
 end
 
+function Checkride.sendChatToUcid(message, ucid)
+    if not message or message == "" or not ucid or ucid == "" then
+        return
+    end
+
+    for id, player in pairs(Checkride.clients) do
+        if player.ucid == ucid then
+            if net and net.send_chat_to then
+                net.send_chat_to(message, id)
+            else
+                Checkride.log("send_chat_to API not available, falling back to broadcast")
+                Checkride.sendChatToAll(message)
+            end
+            return
+        end
+    end
+
+    Checkride.log("sendChatToUcid: no connected player found for ucid " .. ucid)
+end
+
 function Checkride.pollChatSocket()
     if not Checkride.UDPReceiveSocket then
         return
@@ -111,7 +131,11 @@ function Checkride.pollChatSocket()
 
                 if message and message ~= "" then
                     Checkride.log("Received chat message: " .. message)
-                    Checkride.sendChatToAll(message)
+                    if decoded.playerUcid and decoded.playerUcid ~= "" then
+                        Checkride.sendChatToUcid(message, decoded.playerUcid)
+                    else
+                        Checkride.sendChatToAll(message)
+                    end
                 end
             end
         elseif message and message ~= "" then
@@ -189,6 +213,11 @@ local function getPlayerOrAI(playerID)
     return Checkride.clients[playerID] or { name = "AI", ucid = "" }
 end
 
+local function getConnectedPlayerCount()
+    local players = net.get_player_list()
+    return players and #players or 0
+end
+
 local function isBlank(value)
     return value == nil or tostring(value) == ""
 end
@@ -261,6 +290,7 @@ function Checkride.onConnect(time, playerID, name)
     local event = buildEvent("connect", time)
     event.playerUcid = player.ucid
     event.playerName = player.name
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 end
 
@@ -275,6 +305,7 @@ function Checkride.onDisconnect(time, playerID, name, playerSide, reason_code)
     event.playerName = player.name
     event.playerSide = playerSide
     event.reasonCode = reason_code
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 
     Checkride.removePlayer(playerID)
@@ -330,6 +361,7 @@ function Checkride.onChangeSlot(time, playerID, slotID, prevSide)
     event.slotId = slotID
     event.prevSide = prevSide
     event.flyable = isFlyableSlot(side, slotID)
+    event.playerCount = getConnectedPlayerCount()
     Checkride.sendEvent(event)
 end
 
@@ -511,4 +543,5 @@ Checkride.log("Checkride loaded v" .. Checkride.version)
 Checkride.sendEvent({
     type = "ready",
     luaClientVersion = Checkride.clientVersion,
+    playerCount = getConnectedPlayerCount(),
 })

--- a/app/build/lua-versioned/Mods/Services/DCS-Checkride/Scripts/DCS-CheckrideMission.lua
+++ b/app/build/lua-versioned/Mods/Services/DCS-Checkride/Scripts/DCS-CheckrideMission.lua
@@ -6,14 +6,15 @@
 -- Queues encoded events for retrieval via net.dostring_in from GameGUI/hook.
 -- ============================================================================
 CheckrideMission = {}
-CheckrideMission.clientVersion = "1.1.6"
+CheckrideMission.clientVersion = "1.3.2-beta3"
 CheckrideMission.version = CheckrideMission.clientVersion
 CheckrideMission.EventQueue = CheckrideMission.EventQueue or {}
 
 CheckrideMission.FlightSample = {
     enabled = true,
     maxTrackedPilots = 64,
-    tickSeconds = 2.0,
+    targetSampleIntervalSeconds = 4.0,
+    minTickSeconds = 0.25,
     rosterRefreshSeconds = 1.0,
     roster = {},
     nextPilotIndex = 1,
@@ -198,6 +199,26 @@ local GUIDANCE_NAMES = {
     [7]  = "IR",
     [8]  = "LASER",
     [9]  = "TV",
+}
+
+-- Maps Weapon.Category integer → string name.
+local WEAPON_CATEGORY_NAMES = {
+    [0] = "SHELL",
+    [1] = "MISSILE",
+    [2] = "ROCKET",
+    [3] = "BOMB",
+    [4] = "TORPEDO",
+}
+
+-- Maps Weapon.MissileCategory integer → string name.
+-- Missiles matching a sub-category return that name instead of "MISSILE".
+local MISSILE_CATEGORY_NAMES = {
+    [1] = "AAM",
+    [2] = "SAM",
+    [3] = "BM",
+    [4] = "ANTI_SHIP",
+    [5] = "ARM",
+    [6] = "OTHER",
 }
 
 local function isFiniteNumber(value)
@@ -445,13 +466,17 @@ end
 
 function CheckrideMission.sampleTelemetryTick(_, now)
     local cfg = CheckrideMission.FlightSample
+    local minTick = cfg.minTickSeconds or 0.25
+
     if not cfg.enabled then
-        return now + (cfg.tickSeconds or 0.20)
+        return now + minTick
     end
 
     CheckrideMission.refreshTelemetryRoster(now)
 
     local rosterSize = #cfg.roster
+    local tickSeconds = math.max(minTick, (cfg.targetSampleIntervalSeconds or 4.0) / math.max(1, rosterSize))
+
     if rosterSize > 0 then
         if cfg.nextPilotIndex < 1 or cfg.nextPilotIndex > rosterSize then
             cfg.nextPilotIndex = 1
@@ -466,7 +491,7 @@ function CheckrideMission.sampleTelemetryTick(_, now)
         CheckrideMission.emitFlightSampleForEntry(entry, now)
     end
 
-    return now + (cfg.tickSeconds or 0.20)
+    return now + tickSeconds
 end
 
 function CheckrideMission.startTelemetrySampler()
@@ -481,9 +506,11 @@ function CheckrideMission.startTelemetrySampler()
         return
     end
 
-    timer.scheduleFunction(CheckrideMission.sampleTelemetryTick, nil, timer.getTime() + (cfg.tickSeconds or 0.20))
+    local minTick = cfg.minTickSeconds or 0.25
+    timer.scheduleFunction(CheckrideMission.sampleTelemetryTick, nil, timer.getTime() + minTick)
     CheckrideMission.log(
-        "telemetry sampler started: tick=" .. tostring(cfg.tickSeconds or 0.20) ..
+        "telemetry sampler started: targetSampleInterval=" .. tostring(cfg.targetSampleIntervalSeconds or 4.0) ..
+        "s minTick=" .. tostring(minTick) ..
         "s rosterRefresh=" .. tostring(cfg.rosterRefreshSeconds or 1.0) ..
         "s maxTrackedPilots=" .. tostring(cfg.maxTrackedPilots or 64)
     )
@@ -615,18 +642,6 @@ function CheckrideMission.sampleActiveWeaponsTick(_, now)
         local noDataSeconds = now - (track.lastDataAt or track.firedAt or now)
 
         if not isValid or noDataSeconds > (cfg.staleDataSeconds or 30) then
-            CheckrideMission.sendEnrichmentEvent({
-                type              = "inbound_missile_miss",
-                source            = "mission",
-                playerUcid        = track.playerUcid,
-                playerName        = track.playerName,
-                weaponKey         = weaponKey,
-                weaponName        = track.weaponName,
-                weaponGuidance    = track.weaponGuidance,
-                initiatorRole     = track.initiatorRole,
-                initiatorObjectId = track.initiatorObjectId,
-                missionTime       = now,
-            })
             CheckrideMission.activeInboundMissiles[weaponKey] = nil
         else
             track.lastDataAt = now
@@ -1115,55 +1130,23 @@ local function getRoleCoalition(target, initiatorCoalition)
 end
 
 local function classifyWeaponClass(weapon)
-    if not weapon then
-        return "unknown"
+    if not weapon then return "UNKNOWN" end
+
+    local okDesc, desc = pcall(function() return weapon:getDesc() end)
+    if not okDesc or not desc then return "UNKNOWN" end
+
+    local categoryName = WEAPON_CATEGORY_NAMES[desc.category]
+    if not categoryName then return "UNKNOWN" end
+
+    if categoryName == "MISSILE" then
+        return MISSILE_CATEGORY_NAMES[desc.missileCategory] or "MISSILE"
     end
 
-    local weaponName = string.upper(getWeaponTypeName(weapon) or "")
-    if weaponName == "" then
-        return "unknown"
-    end
-
-    local airToAirPatterns = {
-        "AIM[_%-]",
-        "^R[_%-]%d",
-        "MAGIC",
-        "MICA",
-        "SUPER%s*530",
-        "SPARROW",
-        "AMRAAM",
-        "PHOENIX",
-        "SIDEWINDER",
-        "IRIS%-T",
-        "METEOR",
-        "SKYFLASH",
-        "PL%-%d",
-        "SD%-%d",
-    }
-
-    for _, pattern in ipairs(airToAirPatterns) do
-        if string.find(weaponName, pattern) then
-            return "air_to_air_missile"
-        end
-    end
-
-    if string.find(weaponName, "MAVERICK") or string.find(weaponName, "AGM") then
-        return "air_to_ground_missile"
-    end
-
-    if string.find(weaponName, "BOMB") or string.find(weaponName, "MK%-") or string.find(weaponName, "GBU") then
-        return "bomb"
-    end
-
-    if string.find(weaponName, "ROCKET") or string.find(weaponName, "HYDRA") or string.find(weaponName, "S%-8") then
-        return "rocket"
-    end
-
-    return "other"
+    return categoryName
 end
 
 local function isAirToAirMissileClass(weaponClass)
-    return weaponClass == "air_to_air_missile"
+    return weaponClass == "AAM"
 end
 
 local function findInFlightWeaponCandidates(targetObjectId, weaponKey, weaponObjectId)
@@ -1607,8 +1590,8 @@ function CheckrideMission.onHit(event)
             local okVDesc, vDesc = pcall(function() return target:getDesc() end)
             if okVDesc and vDesc and type(vDesc.attributes) == "table" then
                 local wantedRoles = {
-                    "SAM SR","SAM TR","SAM launcher","MANPADS",
-                    "Armor","Tank","MBT","IFV","APC",
+                    "SAM SR","SAM TR","SAM launcher",
+                    "Armour","Tanks","IFV","APC",
                     "AAA","Artillery","MLRS","Infantry",
                 }
                 for _, r in ipairs(wantedRoles) do
@@ -1630,11 +1613,14 @@ function CheckrideMission.onHit(event)
             local okTType, tType = pcall(function() return target:getTypeName() end)
             if okTType and tType and tType ~= "" then victimTypeName = tType end
 
+            local weaponClass = weapon and classifyWeaponClass(weapon) or nil
+
             if targetObjectId then
                 CheckrideMission.pendingKillsByObjectId[targetObjectId] = {
                     killedAtMs      = event.time,
                     victimRoles     = victimRoles,
                     weaponGuidance  = weaponGuidance,
+                    weaponClass     = weaponClass,
                     victimPositionX = victimPoint and victimPoint.x or nil,
                     victimPositionY = victimPoint and victimPoint.z or nil,
                     night           = CheckrideMission.isNight(event.time),
@@ -1645,24 +1631,18 @@ function CheckrideMission.onHit(event)
 
         elseif life and life > 1.0 then
             -- ── Non-lethal hit: emit lightweight hit counter ──────────────────
-            -- Guard: only process if this weapon is actively tracked (missiles/bombs).
-            -- Gun rounds are never added to activeWeaponShots, so this skips the
-            -- expensive pcall + UDP path on every bullet hit.
-            local matchingForHit = findInFlightWeaponCandidates(targetObjectId, weaponKey, weaponObjectId)
-            if #matchingForHit > 0 then
-                local killerCoal = nil
-                pcall(function() killerCoal = initiator:getCoalition() end)
-                local roleCoalition = getRoleCoalition(target, killerCoal)
-                if roleCoalition then
-                    CheckrideMission.sendEnrichmentEvent({
-                        type         = "hit_enrichment",
-                        source       = "mission",
-                        playerUcid   = ucid,
-                        playerName   = playerName,
-                        roleCoalition = roleCoalition,
-                        missionTime  = event.time,
-                    })
-                end
+            local killerCoal = nil
+            pcall(function() killerCoal = initiator:getCoalition() end)
+            local roleCoalition = getRoleCoalition(target, killerCoal)
+            if roleCoalition then
+                CheckrideMission.sendEnrichmentEvent({
+                    type         = "hit_enrichment",
+                    source       = "mission",
+                    playerUcid   = ucid,
+                    playerName   = playerName,
+                    roleCoalition = roleCoalition,
+                    missionTime  = event.time,
+                })
             end
         end
     end
@@ -1837,11 +1817,50 @@ function CheckrideMission.onKill(event)
     local initiator = event.initiator
     if not initiator then return end
 
-    local playerName, unitType, ucid = CheckrideMission.getPlayerInfo(initiator)
-    if not playerName then return end -- AI kill, skip
-
     local target = event.target
     if not target then return end
+
+    -- Emit friendly_killed_enrichment whenever a friendly aircraft is destroyed
+    -- by an enemy, whether the victim is a human player or an AI aircraft.
+    local victimPlayerName = nil
+    local okVPN, vpn = pcall(function() return target:getPlayerName() end)
+    if okVPN and vpn and vpn ~= "" then victimPlayerName = vpn end
+
+    local victimIsAirUnit = false
+    local okVCat, vCat = pcall(function() return target:getDesc() end)
+    if okVCat and vCat then
+        victimIsAirUnit = (vCat.category == Unit.Category.AIRPLANE or vCat.category == Unit.Category.HELICOPTER)
+    end
+
+    local killerCoalForFriendly = nil
+    local victimCoalForFriendly = nil
+    pcall(function() killerCoalForFriendly = initiator:getCoalition() end)
+    pcall(function() victimCoalForFriendly = target:getCoalition() end)
+    local victimIsEnemyKilled = killerCoalForFriendly and victimCoalForFriendly and
+                                killerCoalForFriendly ~= victimCoalForFriendly and
+                                victimCoalForFriendly ~= coalition.side.NEUTRAL
+
+    if victimPlayerName or (victimIsAirUnit and victimIsEnemyKilled) then
+        local killerObjectId = getObjectId(initiator)
+        local killerTypeName = nil
+        local okKType, kType = pcall(function() return initiator:getTypeName() end)
+        if okKType and kType and kType ~= "" then killerTypeName = kType end
+
+        local victimPlayerUcid = victimPlayerName and (CheckrideLookupUCID and CheckrideLookupUCID(victimPlayerName) or nil) or nil
+
+        CheckrideMission.sendEnrichmentEvent({
+            type             = "friendly_killed_enrichment",
+            source           = "mission",
+            killerObjectId   = killerObjectId,
+            killerTypeName   = killerTypeName,
+            victimPlayerName = victimPlayerName,
+            victimPlayerUcid = victimPlayerUcid,
+            missionTime      = event.time,
+        })
+    end
+
+    local playerName, unitType, ucid = CheckrideMission.getPlayerInfo(initiator)
+    if not playerName then return end -- AI kill, skip rest
 
     local victimObjectId = getObjectId(target)
 
@@ -1931,6 +1950,7 @@ function CheckrideMission.onKill(event)
         killedAtMs         = pending and pending.killedAtMs or event.time,
         victimRoles        = pending and pending.victimRoles or nil,
         weaponGuidance     = pending and pending.weaponGuidance or nil,
+        weaponClass        = pending and pending.weaponClass or nil,
         victimPositionX    = pending and pending.victimPositionX or nil,
         victimPositionY    = pending and pending.victimPositionY or nil,
         night              = pending and pending.night or nil,

--- a/app/build/lua-versioned/Scripts/Hooks/DCS-Checkride-hook.lua
+++ b/app/build/lua-versioned/Scripts/Hooks/DCS-Checkride-hook.lua
@@ -13,7 +13,7 @@ local function checkrideLogWarn(message)
     log.write('DCS-Checkride-Hook', warningLevel, tostring(message))
 end
 
-local CHECKRIDE_CLIENT_VERSION = '1.1.6'
+local CHECKRIDE_CLIENT_VERSION = '1.3.2-beta3'
 checkrideLogInfo('Hook version: ' .. CHECKRIDE_CLIENT_VERSION)
 
 local status, result = pcall(function() local dcsSr=require('lfs');dofile(dcsSr.writedir()..[[Mods\Services\DCS-Checkride\Scripts\DCS-CheckrideGameGUI.lua]]); end,nil)

--- a/app/clients/dcsChatClient.js
+++ b/app/clients/dcsChatClient.js
@@ -20,7 +20,7 @@ class DCSChatClient {
     });
   }
 
-  send(message, publish, { kind = 'achievement' } = {}) {
+  send(message, publish, { kind = 'achievement', playerUcid = null } = {}) {
     if (!message) {
       log.info('DCS chat message missing, skipping DCS notification');
       return Promise.resolve();
@@ -31,11 +31,9 @@ class DCSChatClient {
       return Promise.resolve();
     }
 
-    const payload = JSON.stringify({
-      message,
-      kind,
-      source: 'checkride',
-    });
+    const payloadObj = { message, kind, source: 'checkride' };
+    if (playerUcid) payloadObj.playerUcid = playerUcid;
+    const payload = JSON.stringify(payloadObj);
 
     log.info(`Sending DCS chat payload: ${payload}`);
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta1",
+  "version": "1.3.2-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkride-client",
-      "version": "1.3.2-beta1",
+      "version": "1.3.2-beta2",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.4.3",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta2",
+  "version": "1.3.2-beta3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkride-client",
-      "version": "1.3.2-beta2",
+      "version": "1.3.2-beta3",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.4.3",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkride-client",
-  "version": "1.3.1",
+  "version": "1.3.2-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkride-client",
-      "version": "1.3.1",
+      "version": "1.3.2-beta1",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.4.3",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta3",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkride-client",
-      "version": "1.3.2-beta3",
+      "version": "1.3.3",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.4.3",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkride-client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkride-client",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta3",
+  "version": "1.3.3",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta2",
+  "version": "1.3.2-beta3",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkride-client",
-  "version": "1.3.2-beta1",
+  "version": "1.3.2-beta2",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkride-client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkride-client",
-  "version": "1.3.1",
+  "version": "1.3.2-beta1",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/app/services/udpServer.js
+++ b/app/services/udpServer.js
@@ -9,6 +9,10 @@ class UDPServer {
     this.start()
   }
 
+  get onEvent() {
+    return this.onEventCallback;
+  }
+
   set onEvent(callback) {
     this.onEventCallback = callback;
   }


### PR DESCRIPTION
## Summary

- Adds `sendChatToUcid()` to the GameGUI Lua script, routing DCS chat to a specific player via `net.send_chat_to()` using the session ID looked up from the existing `Checkride.clients` map
- Updates `dcsChatClient.js` to accept an optional `playerUcid` option, included in the UDP payload when set
- On `connect`, sends the pilot a private message: _"You can view your pilot progression any time at https://www.checkride.oversweep.com"_

Falls back to broadcast if `net.send_chat_to` is unavailable.

## Test plan

- [ ] Connect a new pilot — confirm they receive the welcome message privately
- [ ] Confirm other pilots do not see the message
- [ ] Confirm existing broadcast chat (achievements, proficiencies) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)